### PR TITLE
fix: todoist module due date

### DIFF
--- a/inkycal/modules/inkycal_todoist.py
+++ b/inkycal/modules/inkycal_todoist.py
@@ -311,7 +311,7 @@ class Todoist(InkycalModule):
             # Parse date in local timezone to ensure correct comparison
             try:
                 due_date = (
-                    arrow.get(task.due.date, "YYYY-MM-DD").replace(tzinfo="local")
+                    arrow.get(task.due.date).replace(tzinfo="local")
                     if task.due
                     else None
                 )


### PR DESCRIPTION
Removed conversion of the todoist due date to a string. Due date comes in as a date from the SDK package and fails when converted to a string.